### PR TITLE
Import all external libraries on every sync

### DIFF
--- a/java/src/com/google/idea/blaze/java/sync/importer/BlazeJavaWorkspaceImporter.java
+++ b/java/src/com/google/idea/blaze/java/sync/importer/BlazeJavaWorkspaceImporter.java
@@ -235,24 +235,22 @@ public final class BlazeJavaWorkspaceImporter {
       workspaceBuilder.jdeps.addAll(jars);
     }
 
-    // Add all deps if this target is in the current working set
-    if (workingSet == null || workingSet.isEmpty() || workingSet.isTargetInWorkingSet(target)) {
-      // Add self, so we pick up our own gen jars if in working set
-      workspaceBuilder.directDeps.add(targetKey);
-      for (Dependency dep : target.getDependencies()) {
-        if (dep.getDependencyType() != DependencyType.COMPILE_TIME) {
-          continue;
-        }
-        // forward deps from java proto_library aspect targets
-        TargetIdeInfo depTarget = targetMap.get(dep.getTargetKey());
-        if (depTarget != null && Kind.JAVA_PROTO_LIBRARY_KINDS.contains(depTarget.getKind())) {
-          workspaceBuilder.directDeps.addAll(
-              depTarget.getDependencies().stream()
-                  .map(Dependency::getTargetKey)
-                  .collect(Collectors.toList()));
-        } else {
-          workspaceBuilder.directDeps.add(dep.getTargetKey());
-        }
+    // Add all deps always - workaround .jdeps missing external dependencies
+    // Add self, so we pick up our own gen jars if in working set
+    workspaceBuilder.directDeps.add(targetKey);
+    for (Dependency dep : target.getDependencies()) {
+      if (dep.getDependencyType() != DependencyType.COMPILE_TIME) {
+        continue;
+      }
+      // forward deps from java proto_library aspect targets
+      TargetIdeInfo depTarget = targetMap.get(dep.getTargetKey());
+      if (depTarget != null && Kind.JAVA_PROTO_LIBRARY_KINDS.contains(depTarget.getKind())) {
+        workspaceBuilder.directDeps.addAll(
+            depTarget.getDependencies().stream()
+                .map(Dependency::getTargetKey)
+                .collect(Collectors.toList()));
+      } else {
+        workspaceBuilder.directDeps.add(dep.getTargetKey());
       }
     }
 


### PR DESCRIPTION
When building with jdk 10 compiler, bazel currently fails to include external dependencies in .jdeps files https://github.com/bazelbuild/bazel/issues/5723#issuecomment-437138252. Even with the bazel builder. The (not officially supported) vanilla builder doesn't even attempt to output dependencies in .jdeps files (https://github.com/bazelbuild/bazel/pull/6587).

This is a sledgehammer workaround of ignoring the working set and always including all external dependencies when importing a project (from https://github.com/bazelbuild/bazel/pull/6587#discussion_r232033852):
>  It might make more sense to just provide a way to disable the Intellij plugins' jdeps handling and use the full classpath.

The root cause of bazel failing to output dependencies to .jdeps files is known https://github.com/google/error-prone-javac/commit/9901a45ff63c1d7bc9263007147dc866272b7fdc so hopefully that fix will eventually find its way into bazel upstream. Making this hack temporary.