### PR TITLE
False target

### DIFF
--- a/base/src/com/google/idea/blaze/base/bazel/BuildSystemProvider.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BuildSystemProvider.java
@@ -127,7 +127,7 @@ public interface BuildSystemProvider {
     FileOperationProvider provider = FileOperationProvider.getInstance();
     for (String filename : possibleBuildFileNames()) {
       File child = new File(directory, filename);
-      if (provider.exists(child)) {
+      if (provider.exists(child) && provider.isFile(child)) {
         return child;
       }
     }


### PR DESCRIPTION
Currently to form the bazel command plugin gets workspace data about added files and modified files. After that it checks if these targets are real bazel targets (have corresponding build files).
The problem occurs when there is no build file but instead directory with the build name.
So to avoid this it is possible to add check `isFile`