### PR TITLE
Create version 2030-12-09 for IntelliJ 2020.3 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,6 +42,13 @@ http_archive(
     url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIU/2020.2.2/ideaIU-2020.2.2.zip",
 )
 
+http_archive(
+    name = "intellij_ue_2020_3",
+    build_file = "@//intellij_platform_sdk:BUILD.ue202",
+    sha256 = "6828e286eb476f5fc98c670433d5cf3bcbc4507ae3134724e10a21eaaa24bacf",
+    url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIU/2020.3/ideaIU-2020.3.zip",
+)
+
 # The plugin api for CLion 2019.3. This is required to build CLwB,
 # and run integration tests.
 http_archive(

--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -168,9 +168,11 @@ def jars_from_output(output):
     """Collect jars for intellij-resolve-files from Java output."""
     if output == None:
         return []
+    source_jars = get_source_jars(output)
+    jars = source_jars
     return [
         jar
-        for jar in ([output.class_jar, output.ijar] + get_source_jars(output))
+        for jar in ([output.ijar if len(source_jars) > 0 and output.ijar else output.class_jar] + source_jars)
         if jar != None and not jar.is_source
     ]
 
@@ -666,12 +668,12 @@ def build_filtered_gen_jar(ctx, target, java, gen_java_sources, srcjars):
     for jar in java.outputs.jars:
         if jar.ijar:
             jar_artifacts.append(jar.ijar)
-        elif jar.class_jar:
-            jar_artifacts.append(jar.class_jar)
         if hasattr(jar, "source_jars") and jar.source_jars:
             source_jar_artifacts.extend(jar.source_jars)
         elif hasattr(jar, "source_jar") and jar.source_jar:
             source_jar_artifacts.append(jar.source_jar)
+    if len(source_jar_artifacts) == 0 or len(jar_artifacts) == 0:
+        jar_artifacts.extend([jar.class_jar for jar in java.outputs.jars if jar.class_jar])
 
     filtered_jar = ctx.actions.declare_file(target.label.name + "-filtered-gen.jar")
     filtered_source_jar = ctx.actions.declare_file(target.label.name + "-filtered-gen-src.jar")

--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -169,7 +169,6 @@ def jars_from_output(output):
     if output == None:
         return []
     source_jars = get_source_jars(output)
-    jars = source_jars
     return [
         jar
         for jar in ([output.ijar if len(source_jars) > 0 and output.ijar else output.class_jar] + source_jars)
@@ -539,6 +538,40 @@ def get_java_provider(target):
         return target[JavaInfo]
     return None
 
+def import_as_java_source(kind, sources):
+    """Whether to import the given target as source or as a library.
+
+    https://github.com/bazelbuild/intellij/blob/28548e388093f986bb8fbd666917c3b42c434f6d/java/src/com/google/idea/blaze/java/sync/importer/JavaSourceFilter.java#L113"""
+    # Assume we're interested in all targets, ignore `targets` in the project view
+    return is_java_source_target(kind, sources) or is_java_proto_target(kind)
+
+def is_java_source_target(kind, sources):
+    return can_import_as_java_source(kind) and has_non_generated_sources(sources)
+
+def can_import_as_java_source(kind):
+    return kind not in [
+        "aar_import",
+        "java_import",
+        "java_wrap_cc",
+        "kotlin_stdlib",
+        "kt_jvm_import",
+        "scala_import",
+    ]
+
+def has_non_generated_sources(sources):
+    for source in sources:
+        if source.is_source:
+            return True
+    return False
+
+def is_java_proto_target(kind):
+    return kind in [
+        "java_lite_proto_library",
+        "java_mutable_proto_library",
+        "java_proto_library",
+        "proto_library",
+    ]
+
 def collect_java_info(target, ctx, semantics, ide_info, ide_info_file, output_groups):
     """Updates Java-specific output groups, returns false if not a Java target."""
     java = get_java_provider(target)
@@ -554,7 +587,7 @@ def collect_java_info(target, ctx, semantics, ide_info, ide_info_file, output_gr
     jars = [library_artifact(output) for output in java.outputs.jars]
     class_jars = [output.class_jar for output in java.outputs.jars if output and output.class_jar]
     output_jars = [jar for output in java.outputs.jars for jar in jars_from_output(output)]
-    resolve_files = output_jars
+    resolve_files = [] if import_as_java_source(ctx.rule.kind, sources) else output_jars
     compile_files = class_jars
 
     gen_jars = []

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/noide/NoIdeTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/noide/NoIdeTest.java
@@ -38,7 +38,6 @@ public class NoIdeTest extends BazelIntellijAspectTest {
             testRelative("foo.java-manifest"), testRelative(intellijInfoFileName("foo")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsExactly(
-            testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
             testRelative("libfoo.jdeps"));

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/dependencies/DependenciesTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/dependencies/DependenciesTest.java
@@ -54,13 +54,10 @@ public class DependenciesTest extends BazelIntellijAspectTest {
             testRelative(intellijInfoFileName("transitive_dep")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsAllOf(
-            testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
-            testRelative("libsingle_dep.jar"),
             testRelative("libsingle_dep-hjar.jar"),
             testRelative("libsingle_dep-src.jar"),
-            testRelative("libtransitive_dep.jar"),
             testRelative("libtransitive_dep-hjar.jar"),
             testRelative("libtransitive_dep-src.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))
@@ -103,13 +100,10 @@ public class DependenciesTest extends BazelIntellijAspectTest {
             testRelative(intellijInfoFileName("export_consumer")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsAllOf(
-            testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
-            testRelative("libfoo_exporter.jar"),
             testRelative("libfoo_exporter-hjar.jar"),
             testRelative("libfoo_exporter-src.jar"),
-            testRelative("libexport_consumer.jar"),
             testRelative("libexport_consumer-hjar.jar"),
             testRelative("libexport_consumer-src.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javabinary/JavaBinaryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javabinary/JavaBinaryTest.java
@@ -58,10 +58,8 @@ public class JavaBinaryTest extends BazelIntellijAspectTest {
             testRelative(intellijInfoFileName("foo")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsAllOf(
-            testRelative("libfoolib.jar"),
             testRelative("libfoolib-hjar.jar"),
             testRelative("libfoolib-src.jar"),
-            testRelative("foo.jar"),
             testRelative("foo-src.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))
         .containsExactly(testRelative("libfoolib.jar"), testRelative("foo.jar"));

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javalibrary/JavaLibraryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javalibrary/JavaLibraryTest.java
@@ -123,40 +123,33 @@ public class JavaLibraryTest extends BazelIntellijAspectTest {
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsExactly(
             // foo
-            testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
             testRelative("libfoo.jdeps"),
             // direct
-            testRelative("libdirect.jar"),
             testRelative("libdirect-hjar.jar"),
             testRelative("libdirect-src.jar"),
             testRelative("libdirect.jdeps"),
             // indirect
-            testRelative("libindirect.jar"),
             testRelative("libindirect-hjar.jar"),
             testRelative("libindirect-src.jar"),
             testRelative("libindirect.jdeps"),
             // distant
-            testRelative("libdistant.jar"),
             testRelative("libdistant-hjar.jar"),
             testRelative("libdistant-src.jar"),
             testRelative("libdistant.jdeps"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java-outputs"))
         .containsExactly(
-            testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
             testRelative("libfoo.jdeps"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java-direct-deps"))
         .containsExactly(
             // foo
-            testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
             testRelative("libfoo.jdeps"),
             // direct
-            testRelative("libdirect.jar"),
             testRelative("libdirect-hjar.jar"),
             testRelative("libdirect-src.jar"),
             testRelative("libdirect.jdeps"),

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/jpl/JavaProtoLibraryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/jpl/JavaProtoLibraryTest.java
@@ -106,33 +106,27 @@ public class JavaProtoLibraryTest extends BazelIntellijAspectTest {
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsExactly(
             // lib
-            testRelative("liblib.jar"),
             testRelative("liblib-hjar.jar"),
             testRelative("liblib-src.jar"),
             testRelative("liblib.jdeps"),
             // bar_proto
-            testRelative("libbar_proto-speed.jar"),
             testRelative("libbar_proto-speed-hjar.jar"),
             testRelative("bar_proto-speed-src.jar"),
             // foo_proto
-            testRelative("libfoo_proto-speed.jar"),
             testRelative("libfoo_proto-speed-hjar.jar"),
             testRelative("foo_proto-speed-src.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java-outputs"))
         .containsExactly(
-            testRelative("liblib.jar"),
             testRelative("liblib-hjar.jar"),
             testRelative("liblib-src.jar"),
             testRelative("liblib.jdeps"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java-direct-deps"))
         .containsAllOf(
             // lib
-            testRelative("liblib.jar"),
             testRelative("liblib-hjar.jar"),
             testRelative("liblib-src.jar"),
             testRelative("liblib.jdeps"),
             // bar_proto
-            testRelative("libbar_proto-speed.jar"),
             testRelative("libbar_proto-speed-hjar.jar"),
             testRelative("bar_proto-speed-src.jar"),
             // foo_proto (only hjar)

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalabinary/ScalaBinaryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalabinary/ScalaBinaryTest.java
@@ -48,7 +48,7 @@ public class ScalaBinaryTest extends BazelIntellijAspectTest {
             testRelative(intellijInfoFileName("foolib")),
             testRelative(intellijInfoFileName("foo")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
-        .containsAllOf(testRelative("foolib.jar"), testRelative("foo.jar"));
+        .containsAllOf(testRelative("foolib-ijar.jar"), testRelative("foo.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))
         .containsAllOf(testRelative("foolib.jar"), testRelative("foo.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-generic")).isEmpty();

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalalibrary/ScalaLibraryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalalibrary/ScalaLibraryTest.java
@@ -45,7 +45,7 @@ public class ScalaLibraryTest extends BazelIntellijAspectTest {
     // Also contains ijars for scala-library.
     // Also contains jars + srcjars for liblibrary.
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
-        .contains(testRelative("simple.jar"));
+        .contains(testRelative("simple-ijar.jar"));
 
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-java"))
         .contains(testRelative(intellijInfoFileName("simple")));

--- a/base/BUILD
+++ b/base/BUILD
@@ -45,6 +45,7 @@ intellij_plugin_library(
         "intellij-ue-2020.1": ["sdkcompat/v201/META-INF/blaze-base-v201.xml"],
         "intellij-2020.2": ["sdkcompat/v201/META-INF/blaze-base-v201.xml"],
         "intellij-ue-2020.2": ["sdkcompat/v201/META-INF/blaze-base-v201.xml"],
+        "intellij-ue-2020.3": ["sdkcompat/v201/META-INF/blaze-base-v201.xml"],
         "clion-2019.3": [],
         "clion-2020.1": ["sdkcompat/v201/META-INF/blaze-base-v201.xml"],
     }),

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -515,6 +515,7 @@
     <VcsSyncListener implementation="com.google.idea.blaze.base.sync.libraries.ExternalLibraryManager$VcsListener"/>
     <SettingsUiContributor implementation="com.google.idea.blaze.base.settings.ui.BlazeUserSettingsConfigurable$UiContributor" order="first" id="base"/>
     <MacroTargetProvider implementation="com.google.idea.blaze.base.query.BlazeQueryMacroTargetProvider" order="last"/>
+    <ArtifactStateHelper implementation="com.google.idea.blaze.base.filecache.LocalArtifactStateProtoConverter"/>
     <BinaryPathRemapper implementation="com.google.idea.blaze.base.async.process.MacBinaryPathRemapper" order="last"/>
     <CustomFormatter implementation="com.google.idea.blaze.base.buildmodifier.BuildifierCustomFormatter"/>
   </extensions>

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/ArgumentCompletionContributorTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/ArgumentCompletionContributorTest.java
@@ -46,7 +46,7 @@ public class ArgumentCompletionContributorTest extends BuildFileIntegrationTestC
   }
 
   @Test
-  public void testIncompleteFuncall() {
+  public void testIncompleteFuncall() throws Throwable {
     completionTester.runWithAutoPopupEnabled(
         () -> {
           BuildFile file =
@@ -69,7 +69,7 @@ public class ArgumentCompletionContributorTest extends BuildFileIntegrationTestC
   }
 
   @Test
-  public void testExistingKeywordArg() {
+  public void testExistingKeywordArg() throws Throwable {
     completionTester.runWithAutoPopupEnabled(
         () -> {
           BuildFile file =
@@ -90,7 +90,7 @@ public class ArgumentCompletionContributorTest extends BuildFileIntegrationTestC
   }
 
   @Test
-  public void testNoArgumentCompletionInComment() {
+  public void testNoArgumentCompletionInComment() throws Throwable {
     completionTester.runWithAutoPopupEnabled(
         () -> {
           BuildFile file =

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/BuildFileAutoCompletionTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/BuildFileAutoCompletionTest.java
@@ -50,7 +50,7 @@ public class BuildFileAutoCompletionTest extends BuildFileIntegrationTestCase {
   }
 
   @Test
-  public void testNoPopupAfterNumber() {
+  public void testNoPopupAfterNumber() throws Throwable {
     completionTester.runWithAutoPopupEnabled(
         () -> {
           createBuildFile(new WorkspacePath("java/com/foo/BUILD"));

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/BuildLabelAutoCompletionTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/BuildLabelAutoCompletionTest.java
@@ -50,7 +50,7 @@ public class BuildLabelAutoCompletionTest extends BuildFileIntegrationTestCase {
   }
 
   @Test
-  public void testPopupAutocompleteAfterSlash() {
+  public void testPopupAutocompleteAfterSlash() throws Throwable {
     completionTester.runWithAutoPopupEnabled(
         () -> {
           createBuildFile(new WorkspacePath("java/com/foo/BUILD"));
@@ -70,7 +70,7 @@ public class BuildLabelAutoCompletionTest extends BuildFileIntegrationTestCase {
   }
 
   @Test
-  public void testPopupAutocompleteAfterColon() {
+  public void testPopupAutocompleteAfterColon() throws Throwable {
     completionTester.runWithAutoPopupEnabled(
         () -> {
           createBuildFile(new WorkspacePath("java/com/foo/BUILD"), "java_library(name = 'target')");
@@ -90,7 +90,7 @@ public class BuildLabelAutoCompletionTest extends BuildFileIntegrationTestCase {
   }
 
   @Test
-  public void testPopupAutocompleteAfterLetter() {
+  public void testPopupAutocompleteAfterLetter() throws Throwable {
     // test for IntelliJ's standard autocomplete popup trigger
     completionTester.runWithAutoPopupEnabled(
         () -> {

--- a/base/tests/utils/integration/com/google/idea/blaze/base/EditorTestHelper.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/EditorTestHelper.java
@@ -55,8 +55,12 @@ public class EditorTestHelper {
   }
 
   public Editor openFileInEditor(VirtualFile file) {
-    EdtTestUtil.runInEdtAndWait(
-        (ThrowableRunnable<Throwable>) () -> testFixture.openFileInEditor(file));
+    try {
+      EdtTestUtil.runInEdtAndWait(
+          (ThrowableRunnable<Throwable>) () -> testFixture.openFileInEditor(file));
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
     return testFixture.getEditor();
   }
 
@@ -126,11 +130,15 @@ public class EditorTestHelper {
 
   public void setCaretPosition(Editor editor, int lineNumber, int columnNumber) {
     final CaretInfo info = new CaretInfo(new LogicalPosition(lineNumber, columnNumber), null);
-    EdtTestUtil.runInEdtAndWait(
-        (ThrowableRunnable<Throwable>)
-            () ->
-                EditorTestUtil.setCaretsAndSelection(
-                    editor, new CaretAndSelectionState(ImmutableList.of(info), null)));
+    try {
+      EdtTestUtil.runInEdtAndWait(
+          (ThrowableRunnable<Throwable>)
+              () ->
+                  EditorTestUtil.setCaretsAndSelection(
+                      editor, new CaretAndSelectionState(ImmutableList.of(info), null)));
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
   }
 
   public void assertCaretPosition(Editor editor, int lineNumber, int columnNumber) {

--- a/golang/BUILD
+++ b/golang/BUILD
@@ -27,6 +27,7 @@ java_library(
         "//intellij_platform_sdk:jsr305",
         "//intellij_platform_sdk:plugin_api",
         "//proto:proto_deps",
+        "//sdkcompat",
         "//third_party/go",
     ],
 )

--- a/golang/src/com/google/idea/blaze/golang/resolve/BlazeGoImportResolver.java
+++ b/golang/src/com/google/idea/blaze/golang/resolve/BlazeGoImportResolver.java
@@ -29,6 +29,7 @@ import com.google.idea.blaze.base.lang.buildfile.psi.FuncallExpression;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.sync.SyncCache;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.google.idea.sdkcompat.general.BaseSdkCompat.SyntheticFileSystemItemCompat;
 import com.intellij.codeInsight.navigation.CtrlMouseHandler;
 import com.intellij.lang.documentation.DocumentationProviderEx;
 import com.intellij.openapi.module.Module;
@@ -152,7 +153,7 @@ class BlazeGoImportResolver implements GoImportResolver {
    * resolve to a build rule in a {@link BuildFile}. We'll just return the {@link BuildFile} with a
    * navigation redirect.
    */
-  private static class GoPackageFileSystemItem extends SyntheticFileSystemItem {
+  private static class GoPackageFileSystemItem extends SyntheticFileSystemItemCompat {
     private final String name;
     private final FuncallExpression rule;
 
@@ -215,7 +216,7 @@ class BlazeGoImportResolver implements GoImportResolver {
     }
 
     @Override
-    public boolean processChildren(PsiElementProcessor<PsiFileSystemItem> psiElementProcessor) {
+    public boolean doProcessChildren(PsiElementProcessor<? super PsiFileSystemItem> psiElementProcessor) {
       return false;
     }
   }

--- a/intellij_platform_sdk/BUILD
+++ b/intellij_platform_sdk/BUILD
@@ -135,6 +135,13 @@ config_setting(
 )
 
 config_setting(
+    name = "intellij-ue-2020.3",
+    values = {
+        "define": "ij_product=intellij-ue-2020.3",
+    },
+)
+
+config_setting(
     name = "android-studio-latest",
     values = {
         "define": "ij_product=android-studio-latest",

--- a/intellij_platform_sdk/build_defs.bzl
+++ b/intellij_platform_sdk/build_defs.bzl
@@ -6,7 +6,7 @@ INDIRECT_IJ_PRODUCTS = {
     "intellij-latest-mac": "intellij-2020.1-mac",
     "intellij-beta": "intellij-2020.2",
     "intellij-canary": "intellij-2020.2",
-    "intellij-ue-latest": "intellij-ue-2020.1",
+    "intellij-ue-latest": "intellij-ue-2020.3",
     "intellij-ue-latest-mac": "intellij-ue-2020.1-mac",
     "intellij-ue-beta": "intellij-ue-2020.2",
     "intellij-ue-canary": "intellij-ue-2020.2",
@@ -51,6 +51,10 @@ DIRECT_IJ_PRODUCTS = {
     "intellij-ue-2020.2-mac": struct(
         ide = "intellij-ue",
         directory = "intellij_ue_2020_2",
+    ),
+    "intellij-ue-2020.3": struct(
+        ide = "intellij-ue",
+        directory = "intellij_ue_2020_3",
     ),
     "android-studio-4.1": struct(
         ide = "android-studio",

--- a/sdkcompat/BUILD
+++ b/sdkcompat/BUILD
@@ -27,6 +27,7 @@ java_library(
         "intellij-ue-2020.1": ["//sdkcompat/v201"],
         "intellij-2020.2": ["//sdkcompat/v202"],
         "intellij-ue-2020.2": ["//sdkcompat/v202"],
+        "intellij-ue-2020.3": ["//sdkcompat/v203"],
         "clion-2019.3": ["//sdkcompat/v193"],
         "clion-2020.1": ["//sdkcompat/v201"],
     }),

--- a/sdkcompat/v202/com/google/idea/sdkcompat/general/BaseSdkCompat.java
+++ b/sdkcompat/v202/com/google/idea/sdkcompat/general/BaseSdkCompat.java
@@ -30,6 +30,9 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.platform.PlatformProjectOpenProcessor;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFileSystemItem;
+import com.intellij.psi.impl.SyntheticFileSystemItem;
+import com.intellij.psi.search.PsiElementProcessor;
 import com.intellij.ui.EditorNotifications;
 import com.intellij.ui.EditorNotificationsImpl;
 import com.intellij.ui.EditorTextField;
@@ -113,6 +116,20 @@ public final class BaseSdkCompat {
 
     void doCollectSlowLineMarkers(
         List<? extends PsiElement> elements, Collection<? super LineMarkerInfo<?>> result);
+  }
+
+  /** #api203: wildcard generics added in 2020.3. */
+  public static abstract class SyntheticFileSystemItemCompat extends SyntheticFileSystemItem {
+    public SyntheticFileSystemItemCompat(Project project) {
+      super(project);
+    }
+
+    @Override
+    public boolean processChildren(PsiElementProcessor<PsiFileSystemItem> psiElementProcessor) {
+      return doProcessChildren(psiElementProcessor);
+    }
+
+    public abstract boolean doProcessChildren(PsiElementProcessor<? super PsiFileSystemItem> psiElementProcessor);
   }
 
   /** #api193: changed in 2020.1 */

--- a/sdkcompat/v203/BUILD
+++ b/sdkcompat/v203/BUILD
@@ -1,0 +1,40 @@
+# Description: Indirections for SDK changes to the underlying platform library.
+
+load("//intellij_platform_sdk:build_defs.bzl", "select_for_ide")
+
+licenses(["notice"])
+
+java_library(
+    name = "v203",
+    srcs = glob([
+        "com/google/idea/sdkcompat/general/**",
+        "com/google/idea/sdkcompat/formatter/**",
+        "com/google/idea/sdkcompat/platform/**",
+        "com/google/idea/sdkcompat/python/**",
+        "com/google/idea/sdkcompat/vcs/**",
+    ]) + select_for_ide(
+        android_studio = glob([
+            "com/google/idea/sdkcompat/cpp/**",
+            "com/google/idea/sdkcompat/java/**",
+        ]),
+        clion = glob([
+            "com/google/idea/sdkcompat/clion/**",
+            "com/google/idea/sdkcompat/cpp/**",
+        ]),
+        intellij = glob([
+            "com/google/idea/sdkcompat/java/**",
+            "com/google/idea/sdkcompat/scala/**",
+        ]),
+        intellij_ue = glob([
+            "com/google/idea/sdkcompat/java/**",
+            "com/google/idea/sdkcompat/scala/**",
+        ]),
+    ),
+    visibility = ["//sdkcompat:__pkg__"],
+    deps = [
+        "//intellij_platform_sdk:jsr305",
+        "//intellij_platform_sdk:plugin_api",
+        "//third_party/python",
+        "//third_party/scala",
+    ],
+)

--- a/sdkcompat/v203/com/google/idea/sdkcompat/clion/ToolchainCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/clion/ToolchainCompat.java
@@ -1,0 +1,10 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.jetbrains.cidr.cpp.toolchains.CPPToolchains.Toolchain;
+
+/** Api compat with 2020.1 #api193 */
+public class ToolchainCompat {
+  public static String getDefaultName() {
+    return Toolchain.getDefault();
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/cpp/IncludedHeadersRootCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/cpp/IncludedHeadersRootCompat.java
@@ -1,0 +1,27 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.jetbrains.cidr.lang.workspace.headerRoots.HeadersSearchPath;
+import com.jetbrains.cidr.lang.workspace.headerRoots.HeadersSearchRoot;
+import com.jetbrains.cidr.lang.workspace.headerRoots.IncludedHeadersRoot;
+
+/**
+ * Compat for {@link IncludedHeadersRoot}.
+ *
+ * <p>#api201
+ */
+public class IncludedHeadersRootCompat {
+  public static boolean isUserHeaders(IncludedHeadersRoot root) {
+    return root.getKind() == HeadersSearchPath.Kind.USER;
+  }
+
+  public static HeadersSearchRoot create(
+      Project project, VirtualFile vf, boolean recursive, boolean isUserHeader) {
+    HeadersSearchPath.Kind kind =
+        isUserHeader ? HeadersSearchPath.Kind.USER : HeadersSearchPath.Kind.SYSTEM;
+    return IncludedHeadersRoot.create(project, vf, recursive, kind);
+  }
+
+  private IncludedHeadersRootCompat() {}
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/cpp/MessageBusSupplier.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/cpp/MessageBusSupplier.java
@@ -1,0 +1,32 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.ListenerDescriptor;
+import com.intellij.util.messages.MessageBus;
+import com.intellij.util.messages.MessageBusOwner;
+import com.intellij.util.messages.impl.MessageBusFactoryImpl;
+
+/** Compat for 2020.1 api changes #api193 */
+public class MessageBusSupplier {
+  public static MessageBus createMessageBus(Project project) {
+    return MessageBusFactoryImpl.createRootBus(new MessageBusOwnerForProject(project));
+  }
+
+  private static class MessageBusOwnerForProject implements MessageBusOwner {
+    private final Project realOwner;
+
+    MessageBusOwnerForProject(Project project) {
+      realOwner = project;
+    }
+
+    @Override
+    public Object createListener(ListenerDescriptor listenerDescriptor) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isDisposed() {
+      return realOwner.isDisposed();
+    }
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/cpp/OCImportGraphCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/cpp/OCImportGraphCompat.java
@@ -1,0 +1,14 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.jetbrains.cidr.lang.preprocessor.OCImportGraph;
+import java.util.Collection;
+
+/** Compat utilities for {@link OCImportGraph}. */
+public class OCImportGraphCompat {
+  // #api193
+  public static Collection<VirtualFile> getAllHeaderRoots(Project project, VirtualFile headerFile) {
+    return OCImportGraph.getInstance(project).getAllHeaderRoots(headerFile);
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/cpp/OCWorkspaceEventCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/cpp/OCWorkspaceEventCompat.java
@@ -1,0 +1,24 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.jetbrains.cidr.lang.workspace.OCWorkspaceEventImpl;
+
+/**
+ * Compat methods for {@link OCWorkspaceEventImpl}.
+ *
+ * <p>#api201
+ */
+public class OCWorkspaceEventCompat {
+  private OCWorkspaceEventCompat() {}
+
+  public static OCWorkspaceEventImpl newEvent(
+      boolean resolveConfigurationsChanged,
+      boolean sourceFilesChanged,
+      boolean compilerSettingsChanged,
+      boolean clientVersionChanged) {
+    return new OCWorkspaceEventImpl(
+        resolveConfigurationsChanged,
+        sourceFilesChanged,
+        compilerSettingsChanged,
+        clientVersionChanged);
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/formatter/DelegatingCodeStyleManagerCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/formatter/DelegatingCodeStyleManagerCompat.java
@@ -1,0 +1,19 @@
+package com.google.idea.sdkcompat.formatter;
+
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.codeStyle.CodeStyleManager;
+
+/**
+ * Compat for {@code DelegatingCodeStyleManager}. {@link CodeStyleManager} got a new method in
+ * 2020.2. #api201
+ */
+public class DelegatingCodeStyleManagerCompat {
+
+  private DelegatingCodeStyleManagerCompat() {}
+
+  // #api201: Method introduced in 2020.2. If not overridden, an exception is thrown upon class
+  // creation.
+  public static void scheduleReformatWhenSettingsComputed(CodeStyleManager delegate, PsiFile file) {
+    delegate.scheduleReformatWhenSettingsComputed(file);
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/general/BaseSdkCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/general/BaseSdkCompat.java
@@ -1,0 +1,190 @@
+package com.google.idea.sdkcompat.general;
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo;
+import com.intellij.codeInsight.daemon.LineMarkerProvider;
+import com.intellij.codeInsight.template.impl.TemplateManagerImpl;
+import com.intellij.diff.DiffContentFactoryImpl;
+import com.intellij.dvcs.branch.BranchType;
+import com.intellij.dvcs.branch.DvcsBranchManager;
+import com.intellij.dvcs.branch.DvcsBranchSettings;
+import com.intellij.find.findUsages.CustomUsageSearcher;
+import com.intellij.find.findUsages.FindUsagesOptions;
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.impl.OpenProjectTask;
+import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.ide.projectView.TreeStructureProvider;
+import com.intellij.ide.projectView.ViewSettings;
+import com.intellij.ide.scratch.ScratchesNamedScope;
+import com.intellij.ide.util.treeView.AbstractTreeNode;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.extensions.ProjectExtensionPointName;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.SdkAdditionalData;
+import com.intellij.openapi.projectRoots.SdkType;
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl;
+import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil;
+import com.intellij.openapi.vcs.FilePath;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.platform.PlatformProjectOpenProcessor;
+import com.intellij.psi.PsiElement;
+import com.intellij.ui.EditorNotifications;
+import com.intellij.ui.EditorNotificationsImpl;
+import com.intellij.ui.EditorTextField;
+import com.intellij.ui.content.ContentManager;
+import com.intellij.usages.Usage;
+import com.intellij.util.ContentUtilEx;
+import com.intellij.util.Processor;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.swing.Icon;
+import javax.swing.JComponent;
+
+/** Provides SDK compatibility shims for base plugin API classes, available to all IDEs. */
+public final class BaseSdkCompat {
+  private BaseSdkCompat() {}
+
+  /** #api193: made public in 2020.1. */
+  public static ProjectExtensionPointName<EditorNotifications.Provider<?>>
+      getEditorNotificationsEp() {
+    return EditorNotificationsImpl.EP_PROJECT;
+  }
+
+  /** #api193: constructor changed in 2020.1. */
+  public static class DvcsBranchManagerAdapter extends DvcsBranchManager {
+    protected DvcsBranchManagerAdapter(
+        Project project, DvcsBranchSettings settings, BranchType[] branchTypes) {
+      super(project, settings, branchTypes);
+    }
+  }
+
+  /** #api193: wildcard generics added in 2020.1. */
+  public abstract static class CustomUsageSearcherAdapter extends CustomUsageSearcher {
+    /** #api193: wildcard generics added in 2020.1. */
+    @Override
+    public void processElementUsages(
+        PsiElement element, Processor<? super Usage> processor, FindUsagesOptions options) {
+      doProcessElementUsages(element, processor, options);
+    }
+
+    protected abstract void doProcessElementUsages(
+        PsiElement element, Processor<? super Usage> processor, FindUsagesOptions options);
+  }
+
+  /** #api193: wildcard generics added in 2020.1. */
+  public interface TreeStructureProviderAdapter extends TreeStructureProvider {
+    @Nullable
+    default Object doGetData(Collection<AbstractTreeNode<?>> selected, String dataId) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    default Object getData(Collection<AbstractTreeNode<?>> selected, String dataId) {
+      return doGetData(selected, dataId);
+    }
+
+    @Override
+    default Collection<AbstractTreeNode<?>> modify(
+        AbstractTreeNode<?> parent,
+        Collection<AbstractTreeNode<?>> children,
+        ViewSettings settings) {
+      return doModify(parent, children, settings);
+    }
+
+    Collection<AbstractTreeNode<?>> doModify(
+        AbstractTreeNode<?> parent,
+        Collection<AbstractTreeNode<?>> children,
+        ViewSettings settings);
+  }
+
+  /** #api201: wildcard generics added in 2020.2. */
+  public interface LineMarkerProviderAdapter extends LineMarkerProvider {
+    @Override
+    default void collectSlowLineMarkers(
+        List<? extends PsiElement> elements, Collection<? super LineMarkerInfo<?>> result) {
+      doCollectSlowLineMarkers(elements, result);
+    }
+
+    void doCollectSlowLineMarkers(
+        List<? extends PsiElement> elements, Collection<? super LineMarkerInfo<?>> result);
+  }
+
+  /** #api193: changed in 2020.1 */
+  public static final String SCRATCHES_SCOPE_NAME = ScratchesNamedScope.scratchesAndConsoles();
+
+  /** #api193: 'project' param removed in 2020.1 */
+  public static void setTemplateTesting(Project project, Disposable parentDisposable) {
+    TemplateManagerImpl.setTemplateTesting(parentDisposable);
+  }
+
+  /** #api193: changed in 2020.1. */
+  @Nullable
+  public static String getActiveToolWindowId(Project project) {
+    return ToolWindowManager.getInstance(project).getActiveToolWindowId();
+  }
+
+  /** Compat class for {@link AllIcons}. */
+  public static final class AllIconsCompat {
+    private AllIconsCompat() {}
+
+    /** #api193: changed in 2020.1. */
+    public static final Icon collapseAll = AllIcons.Actions.Collapseall;
+
+    /** #api193: this is unavailable (and not used) in 2020.1 */
+    public static final Icon disabledRun = AllIcons.Process.Stop;
+
+    /** #api193: this is unavailable (and not used) in 2020.1 */
+    public static final Icon disabledDebug = AllIcons.Process.Stop;
+  }
+
+  /** #api193: SdkConfigurationUtil changed in 2020.1. */
+  public static ProjectJdkImpl createSdk(
+      Collection<? extends Sdk> allSdks,
+      VirtualFile homeDir,
+      SdkType sdkType,
+      @Nullable SdkAdditionalData additionalData,
+      @Nullable String customSdkSuggestedName) {
+    return SdkConfigurationUtil.createSdk(
+        allSdks, homeDir, sdkType, additionalData, customSdkSuggestedName);
+  }
+
+  /** #api201: project opening API changed in 2020.2. */
+  public static void openProject(Project project, Path projectFile) {
+    PlatformProjectOpenProcessor.openExistingProject(
+        /* file= */ projectFile,
+        /* projectDir= */ projectFile,
+        OpenProjectTask.withCreatedProject(project));
+  }
+
+  /** #api193: auto-disposed with UI component in 2020.1+ */
+  public static void disposeEditorTextField(EditorTextField field) {}
+
+  /** #api201: changed in 2020.2 */
+  public static boolean isDisabledPlugin(PluginId id) {
+    return PluginManagerCore.isDisabled(id);
+  }
+
+  /** #api201: changed in 2020.2 */
+  public static Charset guessCharsetFromVcsRevisionData(
+      Project project, byte[] revisionContent, FilePath filePath) {
+    return DiffContentFactoryImpl.guessCharset(project, revisionContent, filePath);
+  }
+
+  /** #api201: ContentUtilEx changed in 2020.2 */
+  public static void addTabbedContent(
+      ContentManager manager,
+      JComponent contentComponent,
+      String groupPrefix,
+      String tabName,
+      boolean select,
+      @Nullable Disposable childDisposable) {
+    ContentUtilEx.addTabbedContent(
+        manager, contentComponent, groupPrefix, tabName, select, childDisposable);
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/general/BaseSdkCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/general/BaseSdkCompat.java
@@ -30,6 +30,9 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.platform.PlatformProjectOpenProcessor;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFileSystemItem;
+import com.intellij.psi.impl.SyntheticFileSystemItem;
+import com.intellij.psi.search.PsiElementProcessor;
 import com.intellij.ui.EditorNotifications;
 import com.intellij.ui.EditorNotificationsImpl;
 import com.intellij.ui.EditorTextField;
@@ -113,6 +116,20 @@ public final class BaseSdkCompat {
 
     void doCollectSlowLineMarkers(
         List<? extends PsiElement> elements, Collection<? super LineMarkerInfo<?>> result);
+  }
+
+  /** #api203: wildcard generics added in 2020.3. */
+  public static abstract class SyntheticFileSystemItemCompat extends SyntheticFileSystemItem {
+    public SyntheticFileSystemItemCompat(Project project) {
+      super(project);
+    }
+
+    @Override
+    public boolean processChildren(PsiElementProcessor<? super PsiFileSystemItem> psiElementProcessor) {
+      return doProcessChildren(psiElementProcessor);
+    }
+
+    public abstract boolean doProcessChildren(PsiElementProcessor<? super PsiFileSystemItem> psiElementProcessor);
   }
 
   /** #api193: changed in 2020.1 */

--- a/sdkcompat/v203/com/google/idea/sdkcompat/platform/ServiceHelperCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/platform/ServiceHelperCompat.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.platform;
+
+import com.google.common.base.Verify;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManager;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.components.ComponentManager;
+import com.intellij.serviceContainer.ComponentManagerImpl;
+import java.util.List;
+import java.util.Optional;
+
+/** #api193: wildcard generics added in 2020.1 */
+public class ServiceHelperCompat {
+  public static <T> void registerService(
+      ComponentManager componentManager,
+      Class<T> key,
+      T implementation,
+      Disposable parentDisposable) {
+    @SuppressWarnings({"rawtypes", "unchecked"}) // #api193: wildcard generics added in 2020.1
+    List<? extends IdeaPluginDescriptor> loadedPlugins = (List) PluginManager.getLoadedPlugins();
+    Optional<? extends IdeaPluginDescriptor> platformPlugin =
+        loadedPlugins.stream()
+            .filter(descriptor -> descriptor.getName().startsWith("IDEA CORE"))
+            .findAny();
+
+    Verify.verify(platformPlugin.isPresent());
+
+    ((ComponentManagerImpl) componentManager)
+        .registerServiceInstance(key, implementation, platformPlugin.get());
+  }
+
+  private ServiceHelperCompat() {}
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/python/PyParserAdapter.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/python/PyParserAdapter.java
@@ -1,0 +1,23 @@
+package com.google.idea.sdkcompat.python;
+
+import com.intellij.lang.SyntaxTreeBuilder;
+import com.jetbrains.python.parsing.ParsingContext;
+import com.jetbrains.python.parsing.PyParser;
+import com.jetbrains.python.parsing.StatementParsing;
+import com.jetbrains.python.psi.LanguageLevel;
+
+/** Compatibility adapter for {@link PyParser}. #api201 */
+public abstract class PyParserAdapter extends PyParser {
+
+  /** #api201: Super method uses new interface SyntaxTreeBuilder in 2020.2 */
+  @Override
+  protected ParsingContext createParsingContext(
+      SyntaxTreeBuilder builder, LanguageLevel languageLevel, StatementParsing.FUTURE futureFlag) {
+    return createParsingContext(SyntaxTreeBuilderWrapper.wrap(builder), languageLevel, futureFlag);
+  }
+
+  protected abstract ParsingContext createParsingContext(
+      SyntaxTreeBuilderWrapper builder,
+      LanguageLevel languageLevel,
+      StatementParsing.FUTURE futureFlag);
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/python/SyntaxTreeBuilderWrapper.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/python/SyntaxTreeBuilderWrapper.java
@@ -1,0 +1,25 @@
+package com.google.idea.sdkcompat.python;
+
+import com.intellij.lang.SyntaxTreeBuilder;
+import java.util.function.Supplier;
+
+/**
+ * Compatibility wrapper to support that constructor of ParsingContext uses new interface
+ * SyntaxTreeBuilder in 2020.2. #api201
+ */
+public interface SyntaxTreeBuilderWrapper extends Supplier<SyntaxTreeBuilder> {
+
+  static SyntaxTreeBuilderWrapper wrap(SyntaxTreeBuilder builder) {
+    return () -> builder;
+  }
+
+  /**
+   * #api201: Compatibility wrapper for marker which is represented by a new interface in 2020.2.
+   */
+  interface MarkerWrapper extends Supplier<SyntaxTreeBuilder.Marker> {
+
+    static MarkerWrapper wrap(SyntaxTreeBuilder.Marker marker) {
+      return () -> marker;
+    }
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/scala/ScalaTestRunLineMarkerProviderCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/scala/ScalaTestRunLineMarkerProviderCompat.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.scala;
+
+import org.jetbrains.plugins.scala.testingSupport.test.ui.ScalaTestRunLineMarkerProvider;
+
+/**
+ * Compat class for {@link ScalaTestRunLineMarkerProvider} which was moved to a different package in
+ * 2020.2. #api201
+ */
+public class ScalaTestRunLineMarkerProviderCompat extends ScalaTestRunLineMarkerProvider {}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/vcs/VcsRepositoryCreatorAdapter.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/vcs/VcsRepositoryCreatorAdapter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.vcs;
+
+import com.intellij.dvcs.repo.Repository;
+import com.intellij.dvcs.repo.VcsRepositoryCreator;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import javax.annotation.Nullable;
+
+/**
+ * Compatibility adapter for {@link VcsRepositoryCreator}. Changed to an interface in 2020.2.
+ * #api201
+ */
+public abstract class VcsRepositoryCreatorAdapter implements VcsRepositoryCreator {
+
+  // #api201: Project parameter necessary to support implementation of createRepositoryIfValid() for
+  // versions <2020.2.
+  protected VcsRepositoryCreatorAdapter(Project myProject) {}
+
+  // #api201: No-arg constructor necessary to avoid an exception from 2020.2 on.
+  protected VcsRepositoryCreatorAdapter() {}
+
+  @Nullable
+  public abstract Repository createRepository(
+      Project project, VirtualFile root, Disposable parentDisposable);
+
+  @Nullable
+  @Override
+  // #api201: Project parameter added in 2020.2
+  public Repository createRepositoryIfValid(
+      Project project, VirtualFile root, Disposable parentDisposable) {
+    return createRepository(project, root, parentDisposable);
+  }
+}

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -12,6 +12,7 @@ java_library(
         "intellij-ue-2020.1": ["@go_2020_1//:go"],
         "intellij-2020.2": ["@go_2020_2//:go"],
         "intellij-ue-2020.2": ["@go_2020_2//:go"],
+        "intellij-ue-2020.3": ["@go_2020_2//:go"],
         "default": [],
     }),
 )

--- a/third_party/javascript/BUILD
+++ b/third_party/javascript/BUILD
@@ -11,6 +11,7 @@ java_library(
     exports = select_for_plugin_api({
         "intellij-ue-2020.1": ["@intellij_ue_2020_1//:javascript"],
         "intellij-ue-2020.2": ["@intellij_ue_2020_2//:javascript"],
+        "intellij-ue-2020.3": ["@intellij_ue_2020_3//:javascript"],
         "clion-2019.3": ["@clion_2019_3//:javascript"],
         "clion-2020.1": ["@clion_2020_1//:javascript"],
         "default": [],
@@ -24,6 +25,7 @@ java_library(
     exports = select_for_plugin_api({
         "intellij-ue-2020.1": ["@intellij_ue_2020_1//:css"],
         "intellij-ue-2020.2": ["@intellij_ue_2020_2//:css"],
+        "intellij-ue-2020.3": ["@intellij_ue_2020_3//:css"],
         "clion-2019.3": ["@clion_2019_3//:css"],
         "clion-2020.1": ["@clion_2020_1//:css"],
         "default": [],
@@ -37,6 +39,7 @@ java_library(
     exports = select_for_plugin_api({
         "intellij-ue-2020.1": ["@intellij_ue_2020_1//:tslint"],
         "intellij-ue-2020.2": ["@intellij_ue_2020_2//:tslint"],
+        "intellij-ue-2020.3": ["@intellij_ue_2020_3//:tslint"],
         "clion-2019.3": ["@clion_2019_3//:tslint"],
         "clion-2020.1": ["@clion_2020_1//:tslint"],
         "default": [],
@@ -50,6 +53,7 @@ java_library(
     exports = select_for_plugin_api({
         "intellij-ue-2020.1": ["@intellij_ue_2020_1//:angular"],
         "intellij-ue-2020.2": ["@intellij_ue_2020_2//:angular"],
+        "intellij-ue-2020.3": ["@intellij_ue_2020_3//:angular"],
         "clion-2019.3": ["@intellij_ue_2019_3//:angular"],
         "clion-2020.1": ["@intellij_ue_2020_1//:angular"],
         "default": [],

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -12,6 +12,7 @@ java_library(
         "intellij-ue-2020.1": ["@python_2020_1//:python"],
         "intellij-2020.2": ["@python_2020_2//:python"],
         "intellij-ue-2020.2": ["@python_2020_2//:python"],
+        "intellij-ue-2020.3": ["@python_2020_2//:python"],
         "clion-2019.3": ["@clion_2019_3//:python"],
         "clion-2020.1": ["@clion_2020_1//:python"],
         "android-studio-4.1": ["@python_2020_1//:python"],

--- a/third_party/scala/BUILD
+++ b/third_party/scala/BUILD
@@ -12,6 +12,7 @@ java_library(
         "intellij-ue-2020.1": ["@scala_2020_1//:scala"],
         "intellij-2020.2": ["@scala_2020_2//:scala"],
         "intellij-ue-2020.2": ["@scala_2020_2//:scala"],
+        "intellij-ue-2020.3": ["@scala_2020_2//:scala"],
         "default": [],
     }),
 )

--- a/version.bzl
+++ b/version.bzl
@@ -4,4 +4,4 @@
 # default version to 9999 so that a dev plugin built from Piper HEAD will override any production
 # plugin (because IntelliJ will choose the highest version when it sees two conflicting plugins, so
 # 9999 > 2017.06.05.0.1).
-VERSION = "9999"
+VERSION = "2030.12.09.0.0"


### PR DESCRIPTION
I've isolated the more mechanical changes and file copies to one commit so you can just look at the latest one to see the actual changes required by the new sdk (not much).

Steps I followed to do this:
* Synced master to upstream master.
* Cherry-picked commits from 2030-09-29 that look still relevant and don't conflict with upstream fixes (with `cherry-pick -x`).
* Mechanically added a new target for IntelliJ UE 2020.3 as a copy of 2020.2, except that it depends on the new SDK.
* Fixed compilation errors due to the new SDK. They were mostly trivial changes around adding `throws` clauses in test code. There was one simple change to an API that had to be added to BaseSdkCompat (for v202 and v203 only -- on the advice of @mskonovalov).
* Built the plugin (in a linux vm) with 
  `bazel build //ijwb:ijwb_bazel_zip --define=ij_product=intellij-ue-2020.3`
* Ran the tests in a docker container that upstream uses on CI: 
  `bazel test :ijwb_ue_tests --define=ij_product=intellij-ue-2020.3`. Results below. [Failures logs here.](https://gist.github.com/watk/dbcbdc2bab9570b3ada5765630c8db88).
```
INFO: Build completed, 2 tests FAILED, 1007 total actions
//base:integration_tests                                                 PASSED in 100.6s
//base:unit_tests                                                        PASSED in 18.9s
//dart:unit_tests                                                        PASSED in 5.7s
//golang:integration_tests                                               PASSED in 71.4s
//golang:unit_tests                                                      PASSED in 15.6s
//ijwb:integration_tests                                                 PASSED in 48.5s
//ijwb:unit_tests                                                        PASSED in 4.3s
//java:unit_tests                                                        PASSED in 22.9s
//javascript:integration_tests                                           PASSED in 82.8s
//javascript:unit_tests                                                  PASSED in 4.5s
//kotlin:integration_tests                                               PASSED in 68.8s
//kotlin:unit_tests                                                      PASSED in 6.7s
//plugin_dev:integration_tests                                           PASSED in 41.9s
//scala:unit_tests                                                       PASSED in 8.0s
//java:integration_tests                                                 FAILED in 86.6s
  /root/.cache/bazel/_bazel_root/4858dab5b4ac16ad2b7d274698c2532a/execroot/intellij_with_bazel/bazel-out/k8-fastbuild/testlogs/java/integration_tests/test.log
//scala:integration_tests                                                FAILED in 31.6s
  /root/.cache/bazel/_bazel_root/4858dab5b4ac16ad2b7d274698c2532a/execroot/intellij_with_bazel/bazel-out/k8-fastbuild/testlogs/scala/integration_tests/test.log
```

* Tried the plugin in both Intellij Ultimate and Community 2020.3 and it synced the Canva repo project fine. And I was able to click the play button on the LHS of a BUILD file to run a random junit test target.

Questions/Unknowns if anyone knows.

* Do we usually get all tests passing before releasing? The java one might be a problem, but what about the scala ones? Probably irrelevant for our usecase?
* What's the point of the *-mac targets? Is it for native compilation on a mac host? I tried building it on mac but I was running into protobuf C++ compilation errors. Looked like it was including headers from my brew protobuf lib 🙄 .. I didn't debug it and just worked in linux instead.
  - @mskonovalov worked on mac last time, so this is a problem with my environment probably. I tried it in nix-shell but got a different issue.. so sticking to linux for now.
* What's the point of the non-ultimate plugin targets? The ultimate plugin seems to work in both. Is it only when it interacts with the Javascript plugin that only Ultimate has?
* In the 2020.3 build I set the plugin dependencies for golang, python, javascript, and scala to point to their 2020.2 versions. It builds fine, but does this mean it might break at runtime when users have 2020.3 versions of the python plugin for example? It looks like we didn't bother updating the plugin deps for 2030-09-29 either, so I left it as is.