### PR TITLE
Fix Jest tests not runnable

### DIFF
--- a/javascript/src/com/google/idea/blaze/javascript/run/producers/NonBlazeProducerSuppressor.java
+++ b/javascript/src/com/google/idea/blaze/javascript/run/producers/NonBlazeProducerSuppressor.java
@@ -38,7 +38,6 @@ public class NonBlazeProducerSuppressor implements StartupActivity {
   private static final ImmutableList<Class<? extends RunConfigurationProducer<?>>>
       PRODUCERS_TO_SUPPRESS =
           ImmutableList.of(
-              JestRunConfigurationProducer.class,
               // Not suppressing JestRunConfigurationProduce since that prevents Jest tests from
               // running properly, see https://github.com/bazelbuild/intellij/issues/3629
               // JestRunConfigurationProducer.class,

--- a/javascript/src/com/google/idea/blaze/javascript/run/producers/NonBlazeProducerSuppressor.java
+++ b/javascript/src/com/google/idea/blaze/javascript/run/producers/NonBlazeProducerSuppressor.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.intellij.execution.RunConfigurationProducerService;
 import com.intellij.execution.actions.RunConfigurationProducer;
-import com.intellij.javascript.jest.JestRunConfigurationProducer;
 import com.intellij.javascript.protractor.ProtractorRunConfigurationProducer;
 import com.intellij.lang.javascript.buildTools.grunt.rc.GruntRunConfigurationProducer;
 import com.intellij.lang.javascript.buildTools.gulp.rc.GulpRunConfigurationProducer;
@@ -40,6 +39,9 @@ public class NonBlazeProducerSuppressor implements StartupActivity {
       PRODUCERS_TO_SUPPRESS =
           ImmutableList.of(
               JestRunConfigurationProducer.class,
+              // Not suppressing JestRunConfigurationProduce since that prevents Jest tests from
+              // running properly, see https://github.com/bazelbuild/intellij/issues/3629
+              // JestRunConfigurationProducer.class,
               GruntRunConfigurationProducer.class,
               ProtractorRunConfigurationProducer.class,
               GulpRunConfigurationProducer.class,


### PR DESCRIPTION
This is an attempt to fix the annoying issue with Jest tests not runnable in Intellij if we import the project via bazel (importing just `web/` should be fine I reckon), and to save ppl from having to use some `fkn_` scripts. More info in [this Slack thread](https://canva.slack.com/archives/C7883Q2JH/p1656644668287419?thread_ts=1581580515.025300&cid=C7883Q2JH) and https://github.com/bazelbuild/intellij/issues/3629.

I've tried on IJ 2022.1.4 using the bazel plugin from s3 (the _before_) vs. the updated one from this branch [0] (the _after_) 👇 

The `runConfigurations.xml` file seems to be ~~regenerated~~ updated every time Intellij completes its start-up [1]. With the updated plugin, `JestRunConfigurationProvider` isn't included in the `ignoredProducts` and the Jest tests run just fine 🎉 Please note the updated plugin, however, doesn't remove the line, it just doesn't add it in, hence a manual removal is necessary, e.g.

```bash
sed -i '' '/JestRunConfigurationProducer/d' .ijwb/.idea/runConfigurations.xml
```

| before | after |
|-|-|
| ![before](https://user-images.githubusercontent.com/2678063/180391045-1c9f37c2-0f5c-42e9-845f-51a6a135001a.jpg) | ![after](https://user-images.githubusercontent.com/2678063/180391063-a742526b-c5e0-4f57-a870-de159c386082.jpg) |
| ![b](https://user-images.githubusercontent.com/2678063/180391593-3c421104-9093-4315-8bff-e2dd4beb7b4f.jpg) | ![a](https://user-images.githubusercontent.com/2678063/180391584-2d9875cd-8b8b-459a-9249-9af562afad80.jpg) |

- [0] The built plugin [ijwb_bazel.zip](https://canva.slack.com/archives/C7883Q2JH/p1656646150006419?thread_ts=1581580515.025300&cid=C7883Q2JH) FYI, was built using [Uri's suggestion](https://canva.slack.com/archives/C7883Q2JH/p1656646150006419?thread_ts=1581580515.025300&cid=C7883Q2JH)
- [1] Sorry I haven't dug into the plugin code to figure out exactly when the `runConfigurations.xml` is ~~generated~~ updated (nor do I understand what those producers are) 😁 but as I've tried it with the existing plugin, 10 times out of 10, the `JestRunConfigurationProvider` line comes back after IJ completes its initial start-up (before indexing it seems?)